### PR TITLE
Added Simple Auto Mod

### DIFF
--- a/cogs/message_checks.py
+++ b/cogs/message_checks.py
@@ -72,6 +72,38 @@ class AdminCommands(commands.Cog):
             embed.add_field(name=f"Msg: {message.content}", value=f"Link to msg: {message.jump_url}", inline=False)
             embed.set_footer(text=f"ID: {message.author.id}")
             await channel.send(staff.mention, embed=embed)
+            
+        # AUTO MOD
+
+        if len(message.mentions) >= 5:
+            roles = message.guild.roles
+            user = message.author
+
+            # Check's if there is a muted role
+
+            for role in roles:
+                if role.name.upper() == "MUTED":
+                    muted_role = role
+
+            try:
+                # Mutes the user is possible
+                await user.add_roles(muted_role)
+                await message.channel.send(
+                    embed=discord.Embed(
+                        title=f"Stop pinging so much {message.author.name}!",
+                        color=discord.Colour.red()
+                    )
+                )
+
+            except Exception:
+                await message.channel.send(
+                    embed=discord.Embed(
+                        title="Couldn't found any **MUTED** role.",
+                        color=discord.Colour.red()
+                    )
+                )
+
+
 
 def setup(client):
     client.add_cog(AdminCommands(client))


### PR DESCRIPTION
Not a fully feature auto mod, rather a temporary fix to keep the server safe from yes, you guessed it! Mass pingers aka Thee Alt God. 

Although the sole purpose of this code is to mute mass pingers, it still has some flaws. The major one being not able to detect pings in multiple message. It will mute someone if and only if the amount of pings in a single message reaches the 5 pings per message limit. However, if anyone pings at most 4 times in a message and keeps doing it in several messages, the bot won't do a thing.